### PR TITLE
Pass result object to plugin methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = postcss.plugin(plugin, function (plugins) {
         })[0]];
     };
 
-    return function (css) {
+    return function (css, result) {
         if (Object.prototype.toString.call(plugins) !== '[object Object]') {
             throw new Error(plugin + ' cannot be called on a non-object');
         }
@@ -21,9 +21,9 @@ module.exports = postcss.plugin(plugin, function (plugins) {
                 var method = getPlugin(ctx);
                 if (method) {
                     if (rule.nodes) {
-                        method(rule);
+                        method(rule, result);
                     } else {
-                        method(css);
+                        method(css, result);
                     }
                     rule.each(function (r) { r.moveBefore(rule); });
                 } else {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "postcss-import": "^6.2.0",
     "postcss-map": "^0.4.0",
     "postcss-size": "^0.1.0",
     "tap-spec": "^2.2.2",

--- a/test.js
+++ b/test.js
@@ -56,3 +56,16 @@ test('should use the postcss plugin api', function (t) {
     t.ok(plugin().postcssVersion, 'should be able to access version');
     t.equal(plugin().postcssPlugin, name, 'should be able to access name');
 });
+
+test('should receive warnings from result object', function (t) {
+    t.plan(2);
+    var options = {
+        inline: require('postcss-import')({
+            path: [__dirname]
+        })
+    };
+    postcss(plugin(options)).process('@context inline { @import "./fixtures/empty"; }').then(function (result) {
+        t.equal(result.css, '', 'should have empty output');
+        t.equal(result.warnings().length, 1, 'should have warning from postcss-import');
+    });
+});


### PR DESCRIPTION
Fixes #2.

I chose `postcss-import` because I knew it made use of the `result` object, but I'm open to other ideas.
